### PR TITLE
dev: optimizations

### DIFF
--- a/contracts/lib/base64.cairo
+++ b/contracts/lib/base64.cairo
@@ -1,12 +1,15 @@
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.uint256 import Uint256
-from starkware.cairo.common.pow import pow
 from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.memcpy import memcpy
 
-from contracts.lib.tables import get_table_encode, get_char_from_table
+from contracts.lib.tables import get_char_from_table
 from contracts.lib.binary import binary_encode, add_8bit_padding, binary_decode, remove_6bit_padding
+
+const pow_10_6 = 1000000
+const pow_10_8 = 100000000
+const pow_10_16 = 10000000000000000
 
 # Main base64 encoder function
 func base64_encode{range_check_ptr}(original_str_len : felt, original_str : felt*) -> (
@@ -154,10 +157,6 @@ func concatenate_to_24_bits{range_check_ptr}(
     # Make sure only 3 UTF-8 chars are passed
     assert binary_encoded_str_len = 3
 
-    let (pow_10_8) = pow(10, 8)  # 10^8
-
-    let (pow_10_16) = pow(10, 16)  # 10^16
-
     let least_significant_bits = binary_encoded_str[2]  # x * 10^0 = x
 
     let middle_significant_bits = pow_10_8 * binary_encoded_str[1]
@@ -194,8 +193,6 @@ func _recursive_slice{range_check_ptr}(
     if index == sliced_group_len:
         return ()
     end
-
-    let (pow_10_6) = pow(10, 6)
 
     let (q, r) = unsigned_div_rem(src_felt, pow_10_6)
 

--- a/contracts/lib/tables.cairo
+++ b/contracts/lib/tables.cairo
@@ -1,11 +1,14 @@
 from starkware.cairo.common.registers import get_label_location
 from starkware.cairo.common.math_cmp import is_le
 
-#
-func get_table_encode{range_check_ptr}() -> (encoded_table : felt*):
-    let (table_address) = get_label_location(TABLE_ENCODE)
+func get_char_from_table{range_check_ptr}(index : felt) -> (ascii_value : felt):
+    let (is_index_le_63) = is_le(index, 63)
 
-    return (encoded_table=cast(table_address, felt*))
+    assert is_index_le_63 = 1
+
+    let (table) = get_label_location(TABLE_ENCODE)
+
+    return ([table + index])
 
     TABLE_ENCODE:
     dw 'A'
@@ -72,17 +75,4 @@ func get_table_encode{range_check_ptr}() -> (encoded_table : felt*):
     dw '9'
     dw '+'
     dw '/'
-end
-
-func get_char_from_table{range_check_ptr}(index : felt) -> (ascii_value : felt):
-    alloc_locals
-    let (local encoded_table) = get_table_encode()
-
-    let (is_index_le_63) = is_le(index, 63)
-
-    assert is_index_le_63 = 1
-
-    let ascii_value = encoded_table[index]
-
-    return (ascii_value=ascii_value)
 end


### PR DESCRIPTION
This PR contains two optimizations to the code that reduce the number of steps of the test fn from 261288 to 223704. These are:

1) using constants for the powers of 10 values
2) merging `get_table_encode` into `get_char_from_table` 